### PR TITLE
MAM-3931-mentions-not-being-parsed-correctly

### DIFF
--- a/Sources/MastodonMeta/MastodonMetaContent+Node.swift
+++ b/Sources/MastodonMeta/MastodonMetaContent+Node.swift
@@ -177,7 +177,7 @@ extension MastodonMetaContent.Node {
         
         var children: [MastodonMetaContent.Node] = []
         for _element in parent.children {
-            let _text = _element.stringValue.trimmingCharacters(in: .newlines)
+            let _text = _element.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
             
             // scan element text
             _ = scanner.scanUpToString(_text)


### PR DESCRIPTION
Trim whitespace from the end of text being parsed.

What I saw was that in MastodonMetaContent.parse(), when some content ended in a paragraph separator, it would set _text to the value of the string with an additional trailing space, and that would screw up the parser.

Changing it to remove trailing linebreaks and whitespace fixes the issue. (I had two known cases I was testing).

```
var children: [MastodonMetaContent.Node] = []
        for _element in parent.children {
            let _text = _element.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) // may have trailing whitespace
            
            // scan element text
            //
            // What I see is that sometimes _text has a trailing whitespace
            // that is NOT present in parentText.
            //
            // One example:
            //      _element.stringValue: "GitHub \u{2029}" (paragraph separator)
            //      _text: "GitHub "
            //      parentText:
            //            (Substring) "GitHub" {
            //              _slice = (_startIndex = 0[any], _endIndex = 6[utf8], _base = "GitHub")
            //            }
```