### PR TITLE
MAM-4131-lemmy-content-has-excessive-newlines

### DIFF
--- a/Sources/MastodonMeta/MastodonContent+Preprocessor.swift
+++ b/Sources/MastodonMeta/MastodonContent+Preprocessor.swift
@@ -24,6 +24,7 @@ extension MastodonContent {
                 .replacingOccurrences(of: "</h1>|</h2>|</h3>|</h4>|</h5>|</h6>", with: "</strong></p>", options: .regularExpression, range: nil)
                 .replacingOccurrences(of: "<br>|<br/>|<br />", with: "\u{2028}", options: .regularExpression, range: nil)
                 .replacingOccurrences(of: "</pre>", with: "</pre>\u{2029}", range: nil)
+                .replacingOccurrences(of: "\n", with: "", range: nil)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             return content
         }()


### PR DESCRIPTION
this essentially makes it so that we ignore "\n". 

lemmy is literally the only service i've seen that adds it and i'm pretty sure it's to combat clients that don't render html, which we do. rendering both causes us to render 3 linebreaks instead of 1 for lemmy content.